### PR TITLE
Update fontconfig-infinality to newer sources

### DIFF
--- a/fontconfig-infinality/build.sh
+++ b/fontconfig-infinality/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-INFINALITY="http://www.infinality.net/fedora/linux/zips/fontconfig-infinality-1-20111223_2.tar.bz2"
+INFINALITY="http://www.infinality.net/fedora/linux/zips/fontconfig-infinality-1-20130104_1.tar.bz2"
 
 if [ ! -f ${INFINALITY##*/} ]; then
   wget "${INFINALITY}"

--- a/fontconfig-infinality/debian/changelog
+++ b/fontconfig-infinality/debian/changelog
@@ -1,3 +1,9 @@
+fontconfig-infinality (1-2) unstable; urgency=low
+
+  * Updated source archive to latest version
+
+ -- Trevor Bekolay <tbekolay@gmail.com>  Sat, 31 Aug 2013 14:59:45 -0400
+
 fontconfig-infinality (1-1) unstable; urgency=low
 
   * Initial release


### PR DESCRIPTION
This solves an issue with the old fontconfig sources producing incorrect files that had multiple values in <test>. See [fontconfig-infinality #6](https://github.com/Infinality/fontconfig-infinality/issues/6) for more details.

Fonts are noticeably different with these fontconfig files.
